### PR TITLE
ENG-681: replace hardcoded OTP with real SMS-based OTP for user-initi…

### DIFF
--- a/abdm/api/v3/serializers/hip.py
+++ b/abdm/api/v3/serializers/hip.py
@@ -89,7 +89,7 @@ class HipLinkCareContextInitSerializer(Serializer):
 class HipLinkCareContextConfirmSerializer(Serializer):
     class ConfirmationSerializer(Serializer):
         linkRefNumber = CharField(max_length=50, required=True)
-        token = CharField(max_length=20, required=True)
+        token = CharField(min_length=6, max_length=6, required=True)
 
     confirmation = ConfirmationSerializer(required=True)
 

--- a/abdm/api/v3/viewsets/hip.py
+++ b/abdm/api/v3/viewsets/hip.py
@@ -32,10 +32,21 @@ from abdm.models import (
     TransactionStatus,
     TransactionType,
 )
-from abdm.service.helper import uuid, validate_and_format_date
+from abdm.service.helper import ABDMAPIException, validate_and_format_date
 from abdm.service.v3.gateway import GatewayService
 from abdm.settings import plugin_settings as settings
 from abdm.tasks.patient_share import patient_share_on_share
+from abdm.utils.link_otp import (
+    LinkOtpDeliveryError,
+    LinkOtpLockContention,
+    LinkOtpSendRateLimited,
+    LinkOtpThrottled,
+    LinkOtpVerifyStatus,
+    finalize_link_otp_confirmation,
+    init_link_otp,
+    rollback_link_otp_after_gateway_init_failure,
+    verify_link_otp,
+)
 from abdm.utils.patient_identifier import ensure_abdm_patient_identifier
 from abdm.utils.token import (
     get_or_create_scan_and_share_token,
@@ -319,28 +330,57 @@ class HIPCallbackViewSet(GenericViewSet):
             [],
         )
 
-        reference_id = uuid()
-        cache.set(
-            "abdm_user_initiated_linking__" + reference_id,
-            {
-                "reference_id": reference_id,
-                # TODO: generate OTP and send it to the patient
-                "otp": "000000",
-                "abha_address": validated_data.get("abhaAddress"),
-                "patient_id": validated_data.get("patient", [{}])[0].get(
-                    "referenceNumber"
-                ),
-                "care_contexts": care_contexts,
-            },
-        )
+        patient_id = validated_data.get("patient", [{}])[0].get("referenceNumber")
+        patient = Patient.objects.filter(external_id=patient_id).first()
 
-        GatewayService.user_initiated_linking__link__care_context__on_init(
-            {
-                "transaction_id": str(validated_data.get("transactionId")),
-                "request_id": request.headers.get("REQUEST-ID"),
-                "reference_id": reference_id,
-            }
-        )
+        if not patient or not patient.phone_number:
+            logger.warning(
+                f"Patient with ID: {patient_id} not found or has no phone number"
+            )
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            reference_id = init_link_otp(
+                patient_id=patient_id,
+                phone_number=patient.phone_number,
+                abha_address=validated_data.get("abhaAddress"),
+                care_contexts=care_contexts,
+            )
+        except LinkOtpThrottled:
+            return Response(
+                {"detail": "Too many failed attempts. Try again later."},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+        except LinkOtpSendRateLimited:
+            return Response(
+                {"detail": "Too many OTP requests. Try again later."},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+        except LinkOtpDeliveryError:
+            logger.exception(
+                f"Failed to deliver link OTP for patient ID: {patient_id}"
+            )
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        except LinkOtpLockContention:
+            return Response(
+                {"detail": "OTP request already in progress. Try again shortly."},
+                status=status.HTTP_423_LOCKED,
+            )
+
+        try:
+            GatewayService.user_initiated_linking__link__care_context__on_init(
+                {
+                    "transaction_id": str(validated_data.get("transactionId")),
+                    "request_id": request.headers.get("REQUEST-ID"),
+                    "reference_id": reference_id,
+                }
+            )
+        except ABDMAPIException:
+            rollback_link_otp_after_gateway_init_failure(patient_id, reference_id)
+            logger.exception(
+                f"Gateway on-init failed for link OTP reference ID: {reference_id}"
+            )
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         return Response(status=status.HTTP_200_OK)
 
@@ -348,40 +388,66 @@ class HIPCallbackViewSet(GenericViewSet):
     def hip__link__care_context__confirm(self, request):
         validated_data = self.validate_request(request)
 
-        cached_data = cache.get(
-            "abdm_user_initiated_linking__"
-            + validated_data.get("confirmation").get("linkRefNumber")
-        )
+        link_ref_number = validated_data.get("confirmation").get("linkRefNumber")
+        token = validated_data.get("confirmation").get("token")
 
-        if not cached_data:
-            logger.warning(
-                f"Reference ID: {validated_data.get('confirmation').get('linkRefNumber')} not found in cache"
+        try:
+            result = verify_link_otp(
+                reference_id=link_ref_number,
+                token=token,
+            )
+        except LinkOtpLockContention:
+            return Response(
+                {"detail": "OTP verification already in progress. Try again shortly."},
+                status=status.HTTP_423_LOCKED,
             )
 
+        if result.status == LinkOtpVerifyStatus.NOT_FOUND:
+            logger.warning(f"Reference ID: {link_ref_number} not found in cache")
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        if cached_data.get("otp") != validated_data.get("confirmation").get("token"):
-            logger.warning(
-                f"Invalid OTP: {validated_data.get('confirmation').get('token')} for Reference ID: {validated_data.get('confirmation').get('linkRefNumber')}"
+        if result.status in (LinkOtpVerifyStatus.LOCKED_OUT, LinkOtpVerifyStatus.THROTTLED):
+            return Response(
+                {"detail": "Too many failed attempts. Try again later."},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
+        if result.status == LinkOtpVerifyStatus.ATTEMPTS_EXCEEDED:
+            return Response(
+                {"detail": "Too many wrong attempts. Please request a new OTP."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if result.status == LinkOtpVerifyStatus.INVALID:
+            logger.warning(f"Invalid OTP for Reference ID: {link_ref_number}")
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        patient_id = cached_data.get("patient_id")
-        patient = Patient.objects.filter(external_id=patient_id).first()
+        patient = Patient.objects.filter(external_id=result.patient_id).first()
 
         if not patient:
-            logger.warning(f"Patient with ID: {patient_id} not found in the database")
-
+            logger.warning(
+                f"Patient with ID: {result.patient_id} not found in the database"
+            )
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        GatewayService.user_initiated_linking__link__care_context__on_confirm(
-            {
-                "request_id": request.headers.get("REQUEST-ID"),
-                "patient": patient,
-                "care_contexts": cached_data.get("care_contexts"),
-                "hf_id": request.headers.get("x-hip-id"),
-            }
+        try:
+            GatewayService.user_initiated_linking__link__care_context__on_confirm(
+                {
+                    "request_id": request.headers.get("REQUEST-ID"),
+                    "patient": patient,
+                    "care_contexts": result.care_contexts,
+                    "hf_id": request.headers.get("x-hip-id"),
+                }
+            )
+        except ABDMAPIException:
+            logger.exception(
+                f"Gateway on-confirm failed for Reference ID: {link_ref_number}"
+            )
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+        finalize_link_otp_confirmation(
+            reference_id=link_ref_number,
+            patient_id=result.patient_id,
         )
 
         return Response(status=status.HTTP_202_ACCEPTED)

--- a/abdm/settings.py
+++ b/abdm/settings.py
@@ -124,6 +124,14 @@ DEFAULTS = {
     "ABDM_ABHA_NUMBER_IDENTIFIER_SYSTEM_SYSTEM": "https://care.ohc.network/abha_number",
     "ABDM_ABHA_NUMBER_IDENTIFIER_SYSTEM_DISPLAY": "ABHA Number",
     "ABDM_SCAN_AND_SHARE_TOKEN_EXPIRY_TIME": 1800,
+    "ABDM_LINK_OTP_SMS_CONTENT": (
+        "Your OTP to link health records is {otp}. Valid for 5 minutes."
+    ),
+    "ABDM_LINK_OTP_SEND_WINDOW_SECONDS": 3600,
+    "ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW": 5,
+    "ABDM_LINK_OTP_MAX_VERIFY_ATTEMPTS": 3,
+    "ABDM_LINK_OTP_MAX_FAILURES": 5,
+    "ABDM_LINK_OTP_LOCKOUT_SECONDS": 3600,
     "ABDM_ALLOW_UNVERIFIED_ABHA_ACCOUNT": True,
     "AUTH_USER_MODEL": "users.User",
     "CURRENT_DOMAIN": "https://care.ohc.network",

--- a/abdm/tests/test_hip_link_care_context.py
+++ b/abdm/tests/test_hip_link_care_context.py
@@ -1,0 +1,370 @@
+import uuid
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from abdm.api.v3.viewsets.hip import HIPCallbackViewSet
+from abdm.models.base import HealthInformationType
+from abdm.service.helper import ABDMAPIException
+from abdm.settings import plugin_settings
+from abdm.utils.link_otp import (
+    LinkOtpDeliveryError,
+    _failure_count_key,
+    create_link_session,
+    get_active_session,
+    get_link_session,
+    hash_otp,
+    increment_failure_count,
+    set_active_session,
+    set_lockout,
+)
+from care.utils.tests.base import CareAPITestBase
+
+
+@override_settings(
+    USE_SMS=True,
+    SMS_BACKEND="care.utils.sms.backend.console.ConsoleBackend",
+)
+class HipLinkCareContextOtpTestCase(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.user = self.create_user(username="abdm_user_internal")
+        self.patient = self.create_patient(
+            phone_number="+919876543210",
+            blood_group="O+",
+        )
+        self.reference_id = str(uuid.uuid4())
+        self.transaction_id = str(uuid.uuid4())
+        self.factory = APIRequestFactory()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def _init_payload(self):
+        return {
+            "transactionId": self.transaction_id,
+            "abhaAddress": "user@abdm",
+            "patient": [
+                {
+                    "referenceNumber": str(self.patient.external_id),
+                    "careContexts": [{"referenceNumber": "ctx-1"}],
+                    "hiType": HealthInformationType.OP_CONSULTATION,
+                    "count": 1,
+                }
+            ],
+        }
+
+    def _confirm_payload(self, token: str, link_ref_number: str | None = None):
+        return {
+            "confirmation": {
+                "linkRefNumber": link_ref_number or self.reference_id,
+                "token": token,
+            }
+        }
+
+    def _post_init(self):
+        request = self.factory.post(
+            "/api/abdm/api/v3/hip/link/care-context/init",
+            self._init_payload(),
+            format="json",
+        )
+        request.META["HTTP_REQUEST_ID"] = str(uuid.uuid4())
+        force_authenticate(request, user=self.user)
+        view = HIPCallbackViewSet.as_view({"post": "hip__link__care_context__init"})
+        return view(request)
+
+    def _post_confirm(self, token: str, link_ref_number: str | None = None):
+        request = self.factory.post(
+            "/api/abdm/api/v3/hip/link/care-context/confirm",
+            self._confirm_payload(token, link_ref_number),
+            format="json",
+        )
+        request.META["HTTP_REQUEST_ID"] = str(uuid.uuid4())
+        request.META["HTTP_X_HIP_ID"] = "hip-1"
+        force_authenticate(request, user=self.user)
+        view = HIPCallbackViewSet.as_view({"post": "hip__link__care_context__confirm"})
+        return view(request)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_caches_hashed_otp_and_calls_on_init(self, mock_on_init):
+        with patch("abdm.utils.link_otp.uuid4", return_value=self.reference_id):
+            response = self._post_init()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_on_init.assert_called_once()
+
+        cached = get_link_session(self.reference_id)
+        self.assertIsNotNone(cached)
+        self.assertIn("otp_hash", cached)
+        self.assertNotIn("otp", cached)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_confirm"
+    )
+    def test_confirm_rejects_wrong_otp(self, mock_on_confirm):
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id=str(self.patient.external_id),
+            care_contexts=["ctx-1"],
+        )
+
+        response = self._post_confirm("999999")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_on_confirm.assert_not_called()
+        cached = get_link_session(self.reference_id)
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached["failed_attempts"], 1)
+
+    def test_confirm_rejects_blank_token(self):
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id=str(self.patient.external_id),
+            care_contexts=["ctx-1"],
+        )
+
+        response = self._post_confirm("")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_confirm"
+    )
+    def test_confirm_accepts_correct_otp_and_deletes_cache(self, mock_on_confirm):
+        otp = "123456"
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp(otp),
+            abha_address="user@abdm",
+            patient_id=str(self.patient.external_id),
+            care_contexts=["ctx-1"],
+        )
+
+        response = self._post_confirm(otp)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_on_confirm.assert_called_once()
+        self.assertIsNone(get_link_session(self.reference_id))
+
+    @override_settings(USE_SMS=False)
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_fails_closed_when_sms_disabled(self, mock_on_init):
+        response = self._post_init()
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        mock_on_init.assert_not_called()
+        self.assertIsNone(get_link_session(self.reference_id))
+
+    def test_init_rejects_patient_without_phone(self):
+        patient = self.create_patient(phone_number="", blood_group="O+")
+        payload = self._init_payload()
+        payload["patient"][0]["referenceNumber"] = str(patient.external_id)
+
+        request = self.factory.post(
+            "/api/abdm/api/v3/hip/link/care-context/init",
+            payload,
+            format="json",
+        )
+        request.META["HTTP_REQUEST_ID"] = str(uuid.uuid4())
+        force_authenticate(request, user=self.user)
+        view = HIPCallbackViewSet.as_view({"post": "hip__link__care_context__init"})
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_VERIFY_ATTEMPTS", 3)
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_FAILURES", 100)
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_confirm"
+    )
+    def test_confirm_deletes_session_after_max_wrong_attempts(self, mock_on_confirm):
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id=str(self.patient.external_id),
+            care_contexts=["ctx-1"],
+        )
+
+        for _ in range(2):
+            response = self._post_confirm("999999")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self._post_confirm("999999")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Too many wrong attempts", response.data["detail"])
+        mock_on_confirm.assert_not_called()
+        self.assertIsNone(get_link_session(self.reference_id))
+
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW", 1)
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_rate_limits_repeated_sends(self, mock_on_init):
+        with patch("abdm.utils.link_otp.uuid4", side_effect=["ref-1", "ref-2"]):
+            first = self._post_init()
+            second = self._post_init()
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(mock_on_init.call_count, 1)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_supersedes_previous_session(self, mock_on_init):
+        old_reference = "old-reference"
+        new_reference = "new-reference"
+
+        with patch("abdm.utils.link_otp.uuid4", side_effect=[old_reference, new_reference]):
+            self._post_init()
+            response = self._post_init()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(get_link_session(old_reference))
+        self.assertIsNotNone(get_link_session(new_reference))
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_returns_429_when_patient_is_locked_out(self, mock_on_init):
+        set_lockout(str(self.patient.external_id))
+
+        response = self._post_init()
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        mock_on_init.assert_not_called()
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    @patch(
+        "abdm.utils.link_otp.send_link_otp",
+        side_effect=[
+            LinkOtpDeliveryError("Failed to send OTP SMS"),
+            None,
+        ],
+    )
+    def test_init_rolls_back_send_counter_on_sms_failure(self, mock_send, mock_on_init):
+        with patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW", 1):
+            first = self._post_init()
+            second = self._post_init()
+
+        self.assertEqual(first.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        mock_on_init.assert_called_once()
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_confirm"
+    )
+    def test_confirm_clears_failure_counter_on_success(self, mock_on_confirm):
+        patient_id = str(self.patient.external_id)
+        increment_failure_count(patient_id)
+        otp = "123456"
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp(otp),
+            abha_address="user@abdm",
+            patient_id=patient_id,
+            care_contexts=["ctx-1"],
+        )
+
+        response = self._post_confirm(otp)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIsNone(cache.get(_failure_count_key(patient_id)))
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_confirm"
+    )
+    def test_confirm_keeps_session_when_on_confirm_fails(self, mock_on_confirm):
+        otp = "123456"
+        patient_id = str(self.patient.external_id)
+        create_link_session(
+            self.reference_id,
+            otp_hash=hash_otp(otp),
+            abha_address="user@abdm",
+            patient_id=patient_id,
+            care_contexts=["ctx-1"],
+        )
+        set_active_session(patient_id, self.reference_id)
+        mock_on_confirm.side_effect = ABDMAPIException()
+
+        response = self._post_confirm(otp)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertIsNotNone(get_link_session(self.reference_id))
+        self.assertEqual(get_active_session(patient_id), self.reference_id)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    @patch("abdm.utils.link_otp.send_link_otp")
+    @patch(
+        "abdm.utils.link_otp.create_link_session",
+        side_effect=RuntimeError("cache unavailable"),
+    )
+    def test_init_does_not_send_sms_when_cache_write_fails(
+        self, mock_cache, mock_send, mock_on_init
+    ):
+        with self.assertRaises(RuntimeError):
+            self._post_init()
+
+        mock_send.assert_not_called()
+        mock_on_init.assert_not_called()
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    @patch(
+        "abdm.utils.link_otp.send_link_otp",
+        side_effect=[
+            None,
+            LinkOtpDeliveryError("Failed to send OTP SMS"),
+        ],
+    )
+    def test_init_restores_previous_session_when_sms_fails_after_new_cache(
+        self, mock_send, mock_on_init
+    ):
+        old_reference = "old-reference"
+        new_reference = "new-reference"
+
+        with patch("abdm.utils.link_otp.uuid4", side_effect=[old_reference, new_reference]):
+            first = self._post_init()
+            second = self._post_init()
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertIsNotNone(get_link_session(old_reference))
+        self.assertIsNone(get_link_session(new_reference))
+        self.assertEqual(
+            get_active_session(str(self.patient.external_id)),
+            old_reference,
+        )
+        self.assertEqual(mock_on_init.call_count, 1)
+
+    @patch(
+        "abdm.api.v3.viewsets.hip.GatewayService.user_initiated_linking__link__care_context__on_init"
+    )
+    def test_init_cleans_new_session_when_on_init_fails(self, mock_on_init):
+        mock_on_init.side_effect = ABDMAPIException()
+
+        with patch("abdm.utils.link_otp.uuid4", return_value=self.reference_id):
+            response = self._post_init()
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertIsNone(get_link_session(self.reference_id))
+        self.assertIsNone(get_active_session(str(self.patient.external_id)))

--- a/abdm/tests/test_link_otp.py
+++ b/abdm/tests/test_link_otp.py
@@ -1,0 +1,246 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from abdm.settings import plugin_settings
+from abdm.utils.link_otp import (
+    LinkOtpAttemptsExceeded,
+    LinkOtpDeliveryError,
+    LinkOtpSendRateLimited,
+    LinkOtpThrottled,
+    _failure_count_key,
+    check_and_increment_send_count,
+    clear_failure_count,
+    create_link_session,
+    decrement_send_count,
+    delete_link_session,
+    delete_link_session_and_active,
+    finalize_link_otp_confirmation,
+    get_active_session,
+    get_link_session,
+    handle_failed_verify,
+    hash_otp,
+    init_link_otp,
+    is_locked_out,
+    send_link_otp,
+    set_active_session,
+    set_lockout,
+    verify_otp,
+)
+
+
+class LinkOtpUtilsTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_verify_otp_accepts_correct_value(self):
+        otp = "654321"
+        self.assertTrue(verify_otp(otp, hash_otp(otp)))
+
+    def test_verify_otp_rejects_wrong_value(self):
+        self.assertFalse(verify_otp("111111", hash_otp("654321")))
+
+    def test_verify_otp_rejects_blank_or_missing_hash(self):
+        self.assertFalse(verify_otp("", hash_otp("654321")))
+        self.assertFalse(verify_otp("654321", None))
+
+    def test_session_crud_round_trip(self):
+        reference_id = "ref-123"
+        create_link_session(
+            reference_id,
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+        )
+
+        cached = get_link_session(reference_id)
+        self.assertEqual(cached["otp_hash"], hash_otp("123456"))
+        self.assertEqual(cached["failed_attempts"], 0)
+        self.assertNotIn("otp", cached)
+
+        delete_link_session(reference_id)
+        self.assertIsNone(get_link_session(reference_id))
+
+    @override_settings(USE_SMS=False)
+    def test_send_link_otp_fails_when_sms_disabled(self):
+        with self.assertRaises(LinkOtpDeliveryError):
+            send_link_otp("+919876543210", "123456")
+
+    @override_settings(USE_SMS=True)
+    @patch("abdm.utils.link_otp.sms.send_text_message", return_value=0)
+    def test_send_link_otp_fails_when_dispatch_returns_zero(self, mock_send):
+        with self.assertRaises(LinkOtpDeliveryError):
+            send_link_otp("+919876543210", "123456")
+        mock_send.assert_called_once()
+
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW", 2)
+    def test_send_count_enforces_window_cap(self):
+        check_and_increment_send_count("patient-1")
+        check_and_increment_send_count("patient-1")
+        with self.assertRaises(LinkOtpSendRateLimited):
+            check_and_increment_send_count("patient-1")
+
+    def test_decrement_send_count_rolls_back_counter(self):
+        with patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW", 1):
+            check_and_increment_send_count("patient-1")
+            with self.assertRaises(LinkOtpSendRateLimited):
+                check_and_increment_send_count("patient-1")
+
+        decrement_send_count("patient-1")
+        check_and_increment_send_count("patient-1")
+
+    def test_clear_failure_count_clears_lockout(self):
+        set_lockout("patient-1")
+        clear_failure_count("patient-1")
+        self.assertFalse(is_locked_out("patient-1"))
+        self.assertIsNone(cache.get(_failure_count_key("patient-1")))
+
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_VERIFY_ATTEMPTS", 3)
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_FAILURES", 10)
+    def test_handle_failed_verify_invalidates_session_at_cap(self):
+        session = {
+            "reference_id": "ref-1",
+            "patient_id": "patient-1",
+            "otp_hash": hash_otp("123456"),
+            "failed_attempts": 2,
+        }
+        create_link_session(
+            "ref-1",
+            otp_hash=session["otp_hash"],
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+            failed_attempts=2,
+        )
+        set_active_session("patient-1", "ref-1")
+
+        with self.assertRaises(LinkOtpAttemptsExceeded):
+            handle_failed_verify(session)
+
+        self.assertIsNone(get_link_session("ref-1"))
+        self.assertIsNone(get_active_session("patient-1"))
+
+    def test_active_session_helpers(self):
+        set_active_session("patient-1", "ref-1")
+        self.assertEqual(get_active_session("patient-1"), "ref-1")
+
+        create_link_session(
+            "ref-1",
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+        )
+        delete_link_session_and_active("ref-1", "patient-1")
+
+        self.assertIsNone(get_link_session("ref-1"))
+        self.assertIsNone(get_active_session("patient-1"))
+
+    def test_delete_link_session_and_active_leaves_other_active_pointer(self):
+        set_active_session("patient-1", "ref-2")
+        create_link_session(
+            "ref-1",
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+        )
+
+        delete_link_session_and_active("ref-1", "patient-1")
+
+        self.assertIsNone(get_link_session("ref-1"))
+        self.assertEqual(get_active_session("patient-1"), "ref-2")
+
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_VERIFY_ATTEMPTS", 5)
+    @patch.object(plugin_settings, "ABDM_LINK_OTP_MAX_FAILURES", 2)
+    def test_handle_failed_verify_locks_out_patient(self):
+        session = {
+            "reference_id": "ref-1",
+            "patient_id": "patient-1",
+            "otp_hash": hash_otp("123456"),
+            "failed_attempts": 0,
+        }
+        create_link_session(
+            "ref-1",
+            otp_hash=session["otp_hash"],
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+        )
+
+        handle_failed_verify(session)
+        with self.assertRaises(LinkOtpThrottled):
+            handle_failed_verify(get_link_session("ref-1"))
+
+        self.assertTrue(is_locked_out("patient-1"))
+        self.assertIsNone(get_link_session("ref-1"))
+
+    @override_settings(
+        USE_SMS=True,
+        SMS_BACKEND="care.utils.sms.backend.console.ConsoleBackend",
+    )
+    @patch("abdm.utils.link_otp.uuid4", return_value="ref-init")
+    def test_init_link_otp_creates_session_before_sending_sms(self, _mock_uuid):
+        reference_id = init_link_otp(
+            patient_id="patient-1",
+            phone_number="+919876543210",
+            abha_address="user@abdm",
+            care_contexts=["ctx-1"],
+        )
+
+        self.assertEqual(reference_id, "ref-init")
+        cached = get_link_session("ref-init")
+        self.assertIsNotNone(cached)
+        self.assertEqual(get_active_session("patient-1"), "ref-init")
+
+    @override_settings(
+        USE_SMS=True,
+        SMS_BACKEND="care.utils.sms.backend.console.ConsoleBackend",
+    )
+    @patch("abdm.utils.link_otp.uuid4", return_value="new-ref")
+    @patch("abdm.utils.link_otp.send_link_otp", side_effect=LinkOtpDeliveryError("fail"))
+    def test_init_link_otp_rolls_back_on_sms_failure(self, mock_send, _mock_uuid):
+        create_link_session(
+            "old-ref",
+            otp_hash=hash_otp("111111"),
+            abha_address="user@abdm",
+            patient_id="patient-1",
+            care_contexts=["ctx-1"],
+        )
+        set_active_session("patient-1", "old-ref")
+
+        with self.assertRaises(LinkOtpDeliveryError):
+            init_link_otp(
+                patient_id="patient-1",
+                phone_number="+919876543210",
+                abha_address="user@abdm",
+                care_contexts=["ctx-1"],
+            )
+
+        mock_send.assert_called_once()
+        self.assertIsNone(get_link_session("new-ref"))
+        self.assertIsNotNone(get_link_session("old-ref"))
+        self.assertEqual(get_active_session("patient-1"), "old-ref")
+
+    def test_finalize_link_otp_confirmation_clears_session_and_counters(self):
+        patient_id = "patient-1"
+        create_link_session(
+            "ref-1",
+            otp_hash=hash_otp("123456"),
+            abha_address="user@abdm",
+            patient_id=patient_id,
+            care_contexts=["ctx-1"],
+        )
+        set_active_session(patient_id, "ref-1")
+        set_lockout(patient_id)
+
+        finalize_link_otp_confirmation(reference_id="ref-1", patient_id=patient_id)
+
+        self.assertIsNone(get_link_session("ref-1"))
+        self.assertIsNone(get_active_session(patient_id))
+        self.assertFalse(is_locked_out(patient_id))
+
+    def tearDown(self):
+        cache.clear()

--- a/abdm/tests/test_settings.py
+++ b/abdm/tests/test_settings.py
@@ -1,0 +1,8 @@
+from config.settings.test import *  # noqa: F403
+
+INSTALLED_APPS = [*INSTALLED_APPS, "abdm"]  # noqa: F405
+
+PLUGIN_CONFIGS = {  # noqa: F405
+    **PLUGIN_CONFIGS,  # noqa: F405
+    "abdm": {},
+}

--- a/abdm/utils/link_otp.py
+++ b/abdm/utils/link_otp.py
@@ -1,0 +1,335 @@
+import hashlib
+import secrets
+import string
+from dataclasses import dataclass
+from enum import Enum
+from uuid import uuid4
+
+from django.conf import settings as django_settings
+from django.core.cache import cache
+
+from abdm.settings import plugin_settings
+from care.utils import sms
+from care.utils.lock import Lock, ObjectLocked
+
+LINK_OTP_CACHE_PREFIX = "abdm_user_initiated_linking__"
+LINK_OTP_SEND_COUNT_PREFIX = "abdm_link_otp_send__"
+LINK_OTP_FAILURE_COUNT_PREFIX = "abdm_link_otp_failures__"
+LINK_OTP_LOCKOUT_PREFIX = "abdm_link_otp_lockout__"
+LINK_OTP_ACTIVE_SESSION_PREFIX = "abdm_link_otp_active__"
+LINK_OTP_TTL = 300
+LINK_OTP_LENGTH = 6
+
+
+class LinkOtpDeliveryError(Exception):
+    pass
+
+
+class LinkOtpThrottled(Exception):
+    pass
+
+
+class LinkOtpSendRateLimited(Exception):
+    pass
+
+
+class LinkOtpAttemptsExceeded(Exception):
+    pass
+
+
+class LinkOtpLockContention(Exception):
+    pass
+
+
+class LinkOtpVerifyStatus(Enum):
+    VALID = "valid"
+    NOT_FOUND = "not_found"
+    LOCKED_OUT = "locked_out"
+    INVALID = "invalid"
+    ATTEMPTS_EXCEEDED = "attempts_exceeded"
+    THROTTLED = "throttled"
+
+
+@dataclass(frozen=True)
+class LinkOtpVerifyResult:
+    status: LinkOtpVerifyStatus
+    patient_id: str | None = None
+    care_contexts: list | None = None
+
+
+def generate_otp() -> str:
+    return "".join(secrets.choice(string.digits) for _ in range(LINK_OTP_LENGTH))
+
+
+def hash_otp(otp: str) -> str:
+    return hashlib.sha256(otp.encode()).hexdigest()
+
+
+def verify_otp(provided: str, stored_hash: str | None) -> bool:
+    if not provided or not stored_hash:
+        return False
+    provided_hash = hash_otp(provided)
+    return secrets.compare_digest(provided_hash, stored_hash)
+
+
+def _build_cache_key(reference_id: str) -> str:
+    return f"{LINK_OTP_CACHE_PREFIX}{reference_id}"
+
+
+def _send_count_key(patient_id: str) -> str:
+    return f"{LINK_OTP_SEND_COUNT_PREFIX}{patient_id}"
+
+
+def _failure_count_key(patient_id: str) -> str:
+    return f"{LINK_OTP_FAILURE_COUNT_PREFIX}{patient_id}"
+
+
+def _lockout_key(patient_id: str) -> str:
+    return f"{LINK_OTP_LOCKOUT_PREFIX}{patient_id}"
+
+
+def _active_session_key(patient_id: str) -> str:
+    return f"{LINK_OTP_ACTIVE_SESSION_PREFIX}{patient_id}"
+
+
+def _increment_counter(key: str, ttl: int) -> int:
+    if cache.add(key, 1, timeout=ttl):
+        return 1
+    try:
+        return cache.incr(key)
+    except ValueError:
+        cache.set(key, 1, timeout=ttl)
+        return 1
+
+
+def _decrement_counter(key: str) -> None:
+    try:
+        value = cache.decr(key)
+        if value <= 0:
+            cache.delete(key)
+    except ValueError:
+        return
+
+
+def is_locked_out(patient_id: str) -> bool:
+    return cache.get(_lockout_key(patient_id)) is not None
+
+
+def set_lockout(patient_id: str) -> None:
+    cache.set(
+        _lockout_key(patient_id),
+        True,
+        timeout=plugin_settings.ABDM_LINK_OTP_LOCKOUT_SECONDS,
+    )
+
+
+def check_and_increment_send_count(patient_id: str) -> None:
+    ttl = plugin_settings.ABDM_LINK_OTP_SEND_WINDOW_SECONDS
+    count = _increment_counter(_send_count_key(patient_id), ttl)
+    if count > plugin_settings.ABDM_LINK_OTP_MAX_SENDS_PER_WINDOW:
+        _decrement_counter(_send_count_key(patient_id))
+        raise LinkOtpSendRateLimited()
+
+
+def decrement_send_count(patient_id: str) -> None:
+    _decrement_counter(_send_count_key(patient_id))
+
+
+def increment_failure_count(patient_id: str) -> int:
+    ttl = plugin_settings.ABDM_LINK_OTP_LOCKOUT_SECONDS
+    return _increment_counter(_failure_count_key(patient_id), ttl)
+
+
+def clear_failure_count(patient_id: str) -> None:
+    cache.delete(_failure_count_key(patient_id))
+    cache.delete(_lockout_key(patient_id))
+
+
+def get_active_session(patient_id: str) -> str | None:
+    return cache.get(_active_session_key(patient_id))
+
+
+def set_active_session(patient_id: str, reference_id: str) -> None:
+    cache.set(_active_session_key(patient_id), reference_id, timeout=LINK_OTP_TTL)
+
+
+def clear_active_session(patient_id: str) -> None:
+    cache.delete(_active_session_key(patient_id))
+
+
+def delete_link_session_and_active(reference_id: str, patient_id: str) -> None:
+    delete_link_session(reference_id)
+    if get_active_session(patient_id) == reference_id:
+        clear_active_session(patient_id)
+
+
+def send_link_otp(phone_number: str, otp: str) -> None:
+    if not django_settings.USE_SMS:
+        raise LinkOtpDeliveryError("SMS delivery is not enabled")
+
+    content = plugin_settings.ABDM_LINK_OTP_SMS_CONTENT.format(otp=otp)
+    try:
+        sent_count = sms.send_text_message(
+            content=content,
+            recipients=[phone_number],
+        )
+    except Exception as exc:
+        raise LinkOtpDeliveryError("Failed to send OTP SMS") from exc
+
+    if sent_count < 1:
+        raise LinkOtpDeliveryError("Failed to send OTP SMS")
+
+
+def create_link_session(
+    reference_id: str,
+    *,
+    otp_hash: str,
+    abha_address: str,
+    patient_id: str,
+    care_contexts: list,
+    failed_attempts: int = 0,
+) -> None:
+    _save_link_session(
+        reference_id,
+        {
+            "reference_id": reference_id,
+            "otp_hash": otp_hash,
+            "abha_address": abha_address,
+            "patient_id": patient_id,
+            "care_contexts": care_contexts,
+            "failed_attempts": failed_attempts,
+        },
+    )
+
+
+def _save_link_session(reference_id: str, session: dict) -> None:
+    cache.set(_build_cache_key(reference_id), session, timeout=LINK_OTP_TTL)
+
+
+def get_link_session(reference_id: str) -> dict | None:
+    return cache.get(_build_cache_key(reference_id))
+
+
+def delete_link_session(reference_id: str) -> None:
+    cache.delete(_build_cache_key(reference_id))
+
+
+def handle_failed_verify(session: dict) -> None:
+    patient_id = session["patient_id"]
+    reference_id = session["reference_id"]
+
+    failed_attempts = session.get("failed_attempts", 0) + 1
+    session["failed_attempts"] = failed_attempts
+    _save_link_session(reference_id, session)
+
+    failure_count = increment_failure_count(patient_id)
+    if failure_count >= plugin_settings.ABDM_LINK_OTP_MAX_FAILURES:
+        set_lockout(patient_id)
+        delete_link_session(reference_id)
+        clear_active_session(patient_id)
+        raise LinkOtpThrottled()
+
+    if failed_attempts >= plugin_settings.ABDM_LINK_OTP_MAX_VERIFY_ATTEMPTS:
+        delete_link_session(reference_id)
+        clear_active_session(patient_id)
+        raise LinkOtpAttemptsExceeded()
+
+
+def _rollback_new_session(
+    patient_id: str,
+    reference_id: str,
+    previous_reference_id: str | None,
+) -> None:
+    delete_link_session(reference_id)
+    if previous_reference_id:
+        set_active_session(patient_id, previous_reference_id)
+    else:
+        clear_active_session(patient_id)
+
+
+def init_link_otp(
+    *,
+    patient_id: str,
+    phone_number: str,
+    abha_address: str,
+    care_contexts: list,
+) -> str:
+    reference_id = str(uuid4())
+
+    try:
+        with Lock(f"link_otp_send:{patient_id}"):
+            if is_locked_out(patient_id):
+                raise LinkOtpThrottled()
+
+            check_and_increment_send_count(patient_id)
+
+            previous_reference_id = get_active_session(patient_id)
+            otp = generate_otp()
+
+            create_link_session(
+                reference_id,
+                otp_hash=hash_otp(otp),
+                abha_address=abha_address,
+                patient_id=patient_id,
+                care_contexts=care_contexts,
+            )
+            set_active_session(patient_id, reference_id)
+
+            try:
+                send_link_otp(phone_number, otp)
+            except LinkOtpDeliveryError:
+                _rollback_new_session(patient_id, reference_id, previous_reference_id)
+                decrement_send_count(patient_id)
+                raise
+
+            if previous_reference_id:
+                delete_link_session(previous_reference_id)
+    except ObjectLocked as exc:
+        raise LinkOtpLockContention from exc
+
+    return reference_id
+
+
+def rollback_link_otp_after_gateway_init_failure(
+    patient_id: str,
+    reference_id: str,
+) -> None:
+    delete_link_session(reference_id)
+    clear_active_session(patient_id)
+
+
+def verify_link_otp(*, reference_id: str, token: str) -> LinkOtpVerifyResult:
+    try:
+        with Lock(f"link_otp_verify:{reference_id}"):
+            cached_data = get_link_session(reference_id)
+
+            if not cached_data:
+                return LinkOtpVerifyResult(status=LinkOtpVerifyStatus.NOT_FOUND)
+
+            patient_id = cached_data.get("patient_id")
+            if is_locked_out(patient_id):
+                return LinkOtpVerifyResult(status=LinkOtpVerifyStatus.LOCKED_OUT)
+
+            if verify_otp(token, cached_data.get("otp_hash")):
+                return LinkOtpVerifyResult(
+                    status=LinkOtpVerifyStatus.VALID,
+                    patient_id=patient_id,
+                    care_contexts=cached_data.get("care_contexts"),
+                )
+
+            try:
+                handle_failed_verify(cached_data)
+            except LinkOtpThrottled:
+                return LinkOtpVerifyResult(status=LinkOtpVerifyStatus.THROTTLED)
+            except LinkOtpAttemptsExceeded:
+                return LinkOtpVerifyResult(status=LinkOtpVerifyStatus.ATTEMPTS_EXCEEDED)
+
+            return LinkOtpVerifyResult(status=LinkOtpVerifyStatus.INVALID)
+    except ObjectLocked as exc:
+        raise LinkOtpLockContention from exc
+
+
+def finalize_link_otp_confirmation(*, reference_id: str, patient_id: str) -> None:
+    delete_link_session(reference_id)
+    clear_active_session(patient_id)
+    clear_failure_count(patient_id)


### PR DESCRIPTION
…ated care context linking

- Generate, hash (SHA-256), and verify a 6-digit OTP per link session
- Cache session before sending SMS; send SMS before superseding the previous session; call gateway on-init/on-confirm before clearing state so every side effect is recoverable on failure
- Enforce per-patient send-rate limit, per-session attempt cap, and cross-session failure lockout via cache counters under a distributed lock
- Extract all OTP orchestration into abdm/utils/link_otp.py; hip viewset now only handles HTTP, validation, and gateway calls
- Add ABDM_LINK_OTP_SMS_CONTENT and abuse-policy defaults to plugin settings
- Add tests covering the happy path, rollback on SMS/gateway failure, rate limiting, lockout, and session lifecycle