### PR TITLE
Cache the gateway JWK and narrow ABDM retry scope

### DIFF
--- a/abdm/authentication.py
+++ b/abdm/authentication.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import jwt
 import requests
+from django.core.cache import cache
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 
@@ -13,18 +14,49 @@ from care.users.models import User
 
 logger = logging.getLogger(__name__)
 
+JWK_CACHE_KEY_PREFIX = "abdm_gateway_jwk"
+JWK_CACHE_TTL = 60 * 60 * 24  # ABDM rotates its signing key rarely
+
 
 class ABDMAuthentication(JWTAuthentication):
-    def open_id_authenticate(self, url, token):
-        public_key = requests.get(
+    def gateway_jwk(self, url, *, use_cache=True):
+        """Fetch the gateway's signing key, cached.
+
+        This runs on every inbound callback. Uncached and without a timeout it was
+        a blocking call to ABDM in front of every callback endpoint -- so a slow or
+        unreachable gateway held a worker open indefinitely, before the view could
+        store the callback and hand it to celery.
+        """
+        cache_key = f"{JWK_CACHE_KEY_PREFIX}__{url}"
+
+        if use_cache:
+            jwk = cache.get(cache_key)
+            if jwk:
+                return jwk
+
+        response = requests.get(
             url,
             headers={
                 "REQUEST-ID": uuid(),
                 "TIMESTAMP": timestamp(),
                 "X-CM-ID": cm_id(),
             },
+            timeout=settings.ABDM_REQUEST_TIMEOUT,
         )
-        jwk = public_key.json()["keys"][0]
+        response.raise_for_status()
+        jwk = response.json()["keys"][0]
+        cache.set(cache_key, jwk, JWK_CACHE_TTL)
+        return jwk
+
+    def open_id_authenticate(self, url, token):
+        try:
+            return self.decode(token, self.gateway_jwk(url))
+        except jwt.InvalidTokenError:
+            # a rotated key would otherwise fail every callback until the TTL expires
+            logger.info("ABDM token failed against cached JWK, refetching")
+            return self.decode(token, self.gateway_jwk(url, use_cache=False))
+
+    def decode(self, token, jwk):
         public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
         return jwt.decode(
             token, key=public_key, audience="account", algorithms=["RS256"]

--- a/abdm/tasks/link_care_context.py
+++ b/abdm/tasks/link_care_context.py
@@ -1,9 +1,11 @@
 import logging
 
+import requests
 from celery import shared_task
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 
+from abdm.service.helper import uuid
 from abdm.service.v3.gateway import GatewayService
 from abdm.tasks.process_inbound_callback import LOW_PRIORITY
 from care.emr.models.observation import Observation
@@ -13,6 +15,13 @@ from care.emr.models.questionnaire import QuestionnaireResponse
 logger = logging.getLogger(__name__)
 
 User = get_user_model()
+
+# Only network-level failures are worth retrying here. An ABDM-side rejection is
+# deterministic -- retrying it four times just multiplies load on a gateway that is
+# already unhealthy. Those leave an INITIATED Transaction for the nightly
+# retry_failed_care_contexts sweep to pick up, which is fine: linking is not
+# time sensitive.
+RETRY_FOR = (requests.Timeout, requests.ConnectionError)
 
 
 def enqueue_link_care_context(
@@ -24,6 +33,10 @@ def enqueue_link_care_context(
 ):
     link_care_context.apply_async(
         kwargs={
+            # generated here, not per attempt, so the update_or_create in
+            # link__carecontext updates one Transaction instead of inserting a new
+            # row -- and a duplicate link request -- on every retry
+            "reference_id": uuid(),
             "patient_external_id": patient_external_id,
             "care_context": care_context,
             "hf_id": hf_id,
@@ -37,7 +50,7 @@ def enqueue_link_care_context(
 @shared_task(
     name="abdm.link_care_context",
     bind=True,
-    autoretry_for=(Exception,),
+    autoretry_for=RETRY_FOR,
     retry_backoff=True,
     retry_backoff_max=600,
     retry_jitter=True,
@@ -45,6 +58,7 @@ def enqueue_link_care_context(
 )
 def link_care_context(
     self,
+    reference_id: str,
     patient_external_id: str,
     care_context: dict,
     hf_id: str,
@@ -89,6 +103,7 @@ def link_care_context(
 
     GatewayService.link__carecontext(
         {
+            "reference_id": reference_id,
             "patient": patient,
             "care_contexts": [care_context],
             "user": user,

--- a/abdm/tasks/process_inbound_callback.py
+++ b/abdm/tasks/process_inbound_callback.py
@@ -1,5 +1,6 @@
 import logging
 
+import requests
 from celery import shared_task
 
 from abdm.models import CallbackStatus, CallbackType, InboundCallback
@@ -8,6 +9,12 @@ from care.utils.lock import ObjectLocked
 logger = logging.getLogger(__name__)
 
 LOCK_RETRY_COUNTDOWN = 2
+
+# Retry only what a later attempt could plausibly fix: lock contention and network
+# failures reaching ABDM. A payload ABDM will always reject, or a bug in a handler,
+# is recorded on the InboundCallback row for replay instead of being retried four
+# times against an already-degraded gateway.
+RETRY_FOR = (ObjectLocked, requests.Timeout, requests.ConnectionError)
 
 # redis broker priorities are inverted: 0 is consumed first (steps 0/3/6/9)
 HIGH_PRIORITY = 0
@@ -93,7 +100,7 @@ def enqueue_inbound_callback(callback: InboundCallback):
 @shared_task(
     bind=True,
     name="abdm.process_inbound_callback",
-    autoretry_for=(Exception,),
+    autoretry_for=RETRY_FOR,
     retry_backoff=True,
     retry_backoff_max=600,
     retry_jitter=True,
@@ -106,9 +113,7 @@ def process_inbound_callback(self, callback_id: int):
         return
 
     if callback.status == CallbackStatus.COMPLETED:
-        logger.info(
-            "ABDM inbound callback %s already completed; skipping", callback_id
-        )
+        logger.info("ABDM inbound callback %s already completed; skipping", callback_id)
         return
 
     callback.mark_processing()

--- a/tests/test_availability_fixes.py
+++ b/tests/test_availability_fixes.py
@@ -1,0 +1,140 @@
+"""Guards for the three availability fixes.
+
+The shared property: ABDM being slow, unreachable, or rejecting us must not hold a
+request open, must not multiply load on the gateway, and must not corrupt the
+Transaction ledger the nightly sweep relies on.
+"""
+
+from unittest.mock import patch
+
+import jwt
+import requests
+from abdm.authentication import ABDMAuthentication
+from abdm.settings import plugin_settings as abdm_settings
+from abdm.tasks.link_care_context import (
+    RETRY_FOR as LINK_RETRY_FOR,
+)
+from abdm.tasks.link_care_context import (
+    enqueue_link_care_context,
+    link_care_context,
+)
+from abdm.tasks.process_inbound_callback import (
+    RETRY_FOR as CALLBACK_RETRY_FOR,
+)
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+CERT_URL = "https://apis.abdm.gov.in/gateway/v3/certs"
+JWK = {"kty": "RSA", "kid": "test", "n": "abc", "e": "AQAB"}
+CARE_CONTEXT = {
+    "reference": "v2::invoice::7c9f1e5a",
+    "display": "Invoice TR-1-26 on 2026-08-06 06:02:28",
+    "hi_type": "Invoice",
+}
+
+
+# The project cache is Redis with IGNORE_EXCEPTIONS=True, which silently degrades to
+# no-op when Redis is unreachable -- that would make these assertions measure the test
+# environment rather than the caching logic.
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "abdm-availability-tests",
+        }
+    }
+)
+class GatewayJwkCacheTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.auth = ABDMAuthentication()
+
+    def test_jwk_is_fetched_once_and_reused(self):
+        with patch("abdm.authentication.requests.get") as get:
+            get.return_value.json.return_value = {"keys": [JWK]}
+
+            self.assertEqual(self.auth.gateway_jwk(CERT_URL), JWK)
+            self.assertEqual(self.auth.gateway_jwk(CERT_URL), JWK)
+
+            # uncached, this ran on every inbound callback
+            get.assert_called_once()
+
+    def test_fetch_is_bounded_by_a_timeout(self):
+        with patch("abdm.authentication.requests.get") as get:
+            get.return_value.json.return_value = {"keys": [JWK]}
+
+            self.auth.gateway_jwk(CERT_URL)
+
+            self.assertEqual(
+                get.call_args.kwargs["timeout"], abdm_settings.ABDM_REQUEST_TIMEOUT
+            )
+
+    def test_nothing_is_cached_when_the_gateway_errors(self):
+        with patch("abdm.authentication.requests.get") as get:
+            get.return_value.raise_for_status.side_effect = requests.HTTPError("503")
+
+            with self.assertRaises(requests.HTTPError):
+                self.auth.gateway_jwk(CERT_URL)
+
+            get.return_value.raise_for_status.side_effect = None
+            get.return_value.json.return_value = {"keys": [JWK]}
+
+            self.assertEqual(self.auth.gateway_jwk(CERT_URL), JWK)
+
+    def test_rotated_key_refetches_instead_of_failing_until_the_ttl_expires(self):
+        rotated = {**JWK, "kid": "rotated"}
+
+        with (
+            patch("abdm.authentication.requests.get") as get,
+            patch.object(ABDMAuthentication, "decode") as decode,
+        ):
+            get.return_value.json.side_effect = [{"keys": [JWK]}, {"keys": [rotated]}]
+            decode.side_effect = [jwt.InvalidTokenError("stale key"), {"sub": "abdm"}]
+
+            result = self.auth.open_id_authenticate(CERT_URL, "a.token")
+
+            self.assertEqual(result, {"sub": "abdm"})
+            self.assertEqual(get.call_count, 2)
+            self.assertEqual(decode.call_args_list[1].args[1], rotated)
+
+
+class RetryScopeTests(TestCase):
+    def test_only_transient_failures_are_retried(self):
+        # retrying an ABDM rejection multiplies load on an already-degraded gateway
+        for retry_for in (LINK_RETRY_FOR, CALLBACK_RETRY_FOR):
+            self.assertNotIn(Exception, retry_for)
+            self.assertIn(requests.Timeout, retry_for)
+            self.assertIn(requests.ConnectionError, retry_for)
+
+    def test_link_task_declares_the_narrowed_scope(self):
+        self.assertEqual(link_care_context.autoretry_for, LINK_RETRY_FOR)
+
+
+class ReferenceIdTests(TestCase):
+    def test_reference_id_is_fixed_at_enqueue_so_retries_reuse_one_transaction(self):
+        with patch("abdm.tasks.link_care_context.link_care_context") as task:
+            enqueue_link_care_context(
+                patient_external_id="0f1d2c3b-4a59-6879-8a9b-0c1d2e3f4a5b",
+                care_context=CARE_CONTEXT,
+                hf_id="IN1410000017_4",
+            )
+
+            reference_id = task.apply_async.call_args.kwargs["kwargs"]["reference_id"]
+            self.assertTrue(reference_id)
+
+    def test_reference_id_reaches_the_gateway(self):
+        with (
+            patch("abdm.tasks.link_care_context.Patient") as patient_model,
+            patch("abdm.tasks.link_care_context.GatewayService") as gateway,
+        ):
+            patient_model.objects.filter.return_value.first.return_value = object()
+
+            link_care_context.run(
+                reference_id="ref-1",
+                patient_external_id="0f1d2c3b-4a59-6879-8a9b-0c1d2e3f4a5b",
+                care_context=CARE_CONTEXT,
+                hf_id="IN1410000017_4",
+            )
+
+            payload = gateway.link__carecontext.call_args.args[0]
+            self.assertEqual(payload["reference_id"], "ref-1")


### PR DESCRIPTION
Three availability fixes on top of the async migration. Care context delivery is not time sensitive, so each one prefers failing fast and letting the nightly retry_failed_care_contexts sweep catch up, over holding a worker or hammering a gateway that is already unhealthy.

1. ABDMAuthentication.open_id_authenticate fetched the gateway signing key with no timeout and no cache, on every request to every callback endpoint. DRF runs authentication before the view, so this was a blocking, unbounded call to ABDM sitting in front of all 14 callbacks -- the request could not reach the code that stores the callback and returns 202. A slow gateway held the worker indefinitely. Now cached for 24h and bounded by ABDM_REQUEST_TIMEOUT, with a single uncached retry on InvalidTokenError so a rotated key does not fail every callback until the TTL expires.

   Note this overlaps sainak/ENG-688-auth-caching. That branch was cut before 639e903 and reverts clean_care_context_display, so it needs a rebase before it lands -- this change is deliberately self-contained and narrower.

2. link_care_context generated no reference_id, so gateway.py:204 minted a fresh one per attempt and update_or_create inserted a new Transaction row -- and sent ABDM a duplicate link request -- on every retry. It is now fixed at enqueue and reused across attempts, making the call idempotent.

3. Both tasks used autoretry_for=(Exception,), so a payload ABDM will always reject was retried 4 times with backoff. During a gateway outage that multiplies outbound volume ~4x on the same worker pool that report generation uses. Narrowed to requests.Timeout/ConnectionError, plus ObjectLocked for the callback task. Non-transient failures now fail once: care context links leave an INITIATED Transaction for the nightly sweep, and inbound callbacks are recorded on the InboundCallback row for replay.