### PR TITLE
Make reference_id optional so in-flight task messages still bind

### DIFF
--- a/abdm/tasks/link_care_context.py
+++ b/abdm/tasks/link_care_context.py
@@ -58,13 +58,18 @@ def enqueue_link_care_context(
 )
 def link_care_context(
     self,
-    reference_id: str,
     patient_external_id: str,
     care_context: dict,
     hf_id: str,
     user_id: int | None = None,
     questionnaire_response_external_id: str | None = None,
+    # Optional, and last, so messages enqueued by an older revision still bind.
+    # Adding a required parameter to a task signature breaks every message already
+    # sitting on the queue at deploy time.
+    reference_id: str | None = None,
 ):
+    # a message from before this parameter existed falls back to the old behaviour
+    reference_id = reference_id or uuid()
     if questionnaire_response_external_id:
         questionnaire_response = QuestionnaireResponse.objects.filter(
             external_id=questionnaire_response_external_id

--- a/tests/test_availability_fixes.py
+++ b/tests/test_availability_fixes.py
@@ -138,3 +138,32 @@ class ReferenceIdTests(TestCase):
 
             payload = gateway.link__carecontext.call_args.args[0]
             self.assertEqual(payload["reference_id"], "ref-1")
+
+
+class TaskSignatureCompatibilityTests(TestCase):
+    """A message enqueued by the previous revision must still bind.
+
+    Adding a required parameter to a celery task signature breaks every message
+    already on the queue at deploy time -- they fail with TypeError before the task
+    body runs, so no Transaction row is written and the nightly sweep cannot find
+    them. The work is lost silently.
+    """
+
+    def test_message_without_reference_id_still_runs(self):
+        with (
+            patch("abdm.tasks.link_care_context.Patient") as patient_model,
+            patch("abdm.tasks.link_care_context.GatewayService") as gateway,
+        ):
+            patient_model.objects.filter.return_value.first.return_value = object()
+
+            # exactly the kwargs the pre-deploy revision enqueued
+            link_care_context.run(
+                patient_external_id="0f1d2c3b-4a59-6879-8a9b-0c1d2e3f4a5b",
+                care_context=CARE_CONTEXT,
+                hf_id="IN1410000017_4",
+                user_id=None,
+                questionnaire_response_external_id=None,
+            )
+
+            payload = gateway.link__carecontext.call_args.args[0]
+            self.assertTrue(payload["reference_id"])


### PR DESCRIPTION
Adding reference_id as a required parameter broke every link_care_context message already on the queue at deploy time. They failed with TypeError during argument binding -- before the task body ran, so no Transaction row was written and the nightly sweep has no record of them. The backlog drained to empty by failing, and those care context links are lost rather than pending.

reference_id is now optional and last in the signature, falling back to a generated uuid for messages from the previous revision. New messages still carry a stable id from enqueue, so the idempotency fix holds.